### PR TITLE
Modernize the asd files for ASDF 3.3

### DIFF
--- a/metatilities-test.asd
+++ b/metatilities-test.asd
@@ -4,24 +4,20 @@ Author: Gary King
 See file COPYING for details
 |#
 
-(defpackage :metatilities-test-system (:use #:cl #:asdf))
-(in-package :metatilities-test-system)
-
-(defsystem metatilities-test
+(defsystem "metatilities-test"
   :author "Gary Warren King <gwking@metabang.com>"
   :maintainer "Gary Warren King <gwking@metabang.com>"
   :licence "MIT Style License"
   :description "Tests for metatilities"
-  :components ((:module 
+  :components ((:module
 		"setup"
 		:pathname "tests/"
 		:components ((:file "package")
-			     (:file "tests" 
+			     (:file "tests"
 				    :depends-on ("package"))))
 	       (:module
 		"tests"
 		:depends-on ("setup")
 		:components ((:file "test-date-and-time"))))
-  :depends-on (:lift :metatilities))
-
-
+  :depends-on ("lift" "metatilities")
+  :perform (test-op (o c) (symbol-call :lift :run-tests :config :generic)))

--- a/metatilities.asd
+++ b/metatilities.asd
@@ -4,40 +4,24 @@ See the file COPYING for details
 
 |#
 
-(defpackage :metatilities-system (:use #:asdf #:cl))
-(in-package :metatilities-system)
-
-;; try hard
-#+(or)
-;; no, too weird
-(unless (find-system 'asdf-system-connections nil)
- (when (find-package 'asdf-install)
-   (funcall (intern (symbol-name :install) :asdf-install)
-	    'asdf-system-connections)))
-;; give up with a useful (?) error message
-(unless (find-system 'asdf-system-connections nil)
-  (print "The metatilities system works best with asdf-system-connections. See 
+;; Use asdf-system-connections if available. Otherwise, warn the user.
+(if (find-system 'asdf-system-connections nil)
+    (load-system 'asdf-system-connections)
+    (print "The metatilities system works best with asdf-system-connections. See
 http://www.cliki.net/asdf-system-connections for details and download
 instructions."))
 
-;; now try again
-(when (find-system 'asdf-system-connections nil)
-  (operate 'load-op 'asdf-system-connections))
-
-(defsystem metatilities
+(defsystem "metatilities"
   :author "Gary Warren King <gwking@metabang.com>"
   :version "0.6.18"
   :maintainer "Gary Warren King <gwking@metabang.com>"
   :licence "MIT Style license"
   :description "These are the rest of metabang.com's Common Lisp utilities"
   :long-description "These are the rest of metabang.com's Common Lisp utilities and what not."
-  :properties ((:ait-timeout . 10) 
-               (:system-applicable-p . 3))
-  :components ((:module 
+  :components ((:module
 		"extensions"
-		:pathname #.(make-pathname 
-			     :directory '(:relative "dev" "utilities"))
-		:components 
+		:pathname "dev/utilities"
+		:components
 		((:file "package-additional")
 		 (:file "graham"
 			:depends-on ("package-additional"))
@@ -54,58 +38,43 @@ instructions."))
 		 (:file "strings"
 			:depends-on ("package-additional"))
 		 (:file "utilities"
-			:depends-on ("macros" "graham"))  
+			:depends-on ("macros" "graham"))
 		 (:file "searching"
 			:depends-on ("package-additional"))
 		 (:file "views-and-windows"
 			:depends-on ("package-additional"))))
-               (:module 
+               (:module
 		"port"
-		:pathname #.(concatenate
-			     'string "dev/"
+		:pathname #.(strcat "dev/"
 			     (or #+OpenMCL "openmcl"
 				 #+DIGITOOL "mcl"
 				 #+SBCL     "sbcl"
-				 #+allegro  "allegro" 
+				 #+allegro  "allegro"
 				 #-(or OpenMCL DIGITOOL SBCL allegro)
 				 "unsupported")
 			     "/")
 		:components ((:file "generic-lisp")
 			     #+DIGITOOL (:file "pop-up-menu")
-			     (:file "generic-interface-support" 
-				    :depends-on ("generic-lisp" 
+			     (:file "generic-interface-support"
+				    :depends-on ("generic-lisp"
 						 #+DIGITOOL "pop-up-menu"))))
-               (:module 
+               (:module
 		"website"
 		:components
 		((:module "source"
 			  :components ((:static-file "index.md"))))))
-    :in-order-to ((test-op (load-op metatilities-test)))
-    :perform (test-op :after (op c)
-		      (funcall
-		       (intern (symbol-name '#:run-tests) :lift)
-		       :config :generic))
-    :depends-on ((:version :metatilities-base "0.6.0") 
-		 :moptilities
-		 :cl-containers
-		 :metabang-bind
-		 ;:asdf-system-connections
+    :in-order-to ((test-op (test-op "metatilities-test")))
+    :depends-on ((:version "metatilities-base" "0.6.0")
+		 "moptilities"
+		 "cl-containers"
+		 "metabang-bind"
+		 ;"asdf-system-connections"
 		 ))
 
-(defmethod operation-done-p 
-           ((o test-op)
-            (c (eql (find-system 'metatilities))))
-  (values nil))
-
 #+asdf-system-connections
-(asdf:defsystem-connection lift-and-metatilities
-  :requires (lift metatilities-base)
-  :perform (load-op :after (op c)
-                    (use-package (find-package :lift) 
-                                 (find-package :metatilities))
-                    (funcall (intern 
-                              (symbol-name :export-exported-symbols)
-                              'metatilities)
-                             :lift :metatilities)))
-
-
+(defsystem-connection "metatilities/with-lift"
+  :requires ("lift" "metatilities-base")
+  :perform (load-op (o c)
+             (use-package (find-package :lift) (find-package :metatilities))
+             (symbol-call :metatilities :export-exported-symbols
+                          :lift :metatilities)))


### PR DESCRIPTION
Follow secondary system naming convention for system connections.